### PR TITLE
Changed method of cloning mentioned in repo

### DIFF
--- a/app/components/GettingStarted/index.js
+++ b/app/components/GettingStarted/index.js
@@ -18,7 +18,7 @@ function GettingStarted() {
 				<div className={ styles.steps }>
 					<p>Clone the boilerplate if you haven't downloaded it</p>
 					<code className={ styles.codeBlock }>
-						git clone git@github.com:mxstbr/react-boilerplate
+						git clone https://github.com/mxstbr/react-boilerplate.git
 					</code>
 					<p>Run the setup to get everything up and running</p>
 					<code className={ styles.codeBlock }>


### PR DESCRIPTION
This changes the cloning method mentioned in the docs, like the fix that was done here:

https://github.com/mxstbr/react-boilerplate/issues/341
