### PR TITLE
Small Style Cleanup

### DIFF
--- a/app/components/Button/styles.css
+++ b/app/components/Button/styles.css
@@ -40,7 +40,7 @@
   }
 }
 
-@media (max-width: 30rem) {
+@media (max-width: 35rem) {
   .button_collapsable {
     justify-content: center;
     width: 2em;

--- a/app/components/Supporters/index.js
+++ b/app/components/Supporters/index.js
@@ -15,7 +15,7 @@ function Features() {
     <div className={ styles.container }>
       <H2>Supporters</H2>
       <a href="http://reactjsprogram.com/?utm_source=react-boilerplate&utm_medium=banner&utm_campaign=React%20Boilerplate">
-        <img src="https://cloud.githubusercontent.com/assets/7525670/16642421/09f0d97c-440b-11e6-92f6-05d680946629.png" alt="React.js Program – A linear approach to learning the React.js ecosystem!" height="120px" />
+        <img className={ styles.image } src="https://cloud.githubusercontent.com/assets/7525670/16642421/09f0d97c-440b-11e6-92f6-05d680946629.png" alt="React.js Program – A linear approach to learning the React.js ecosystem!" />
       </a>
     </div>
   );

--- a/app/components/Supporters/styles.css
+++ b/app/components/Supporters/styles.css
@@ -4,3 +4,8 @@
   justify-content: center;
   margin: 3rem auto 0;
 }
+
+.image {
+  max-width: 100%;
+  height: auto;
+}

--- a/app/pages/App/styles.css
+++ b/app/pages/App/styles.css
@@ -2,7 +2,6 @@
 
 html,
 body {
-  height: 100%;
   width: 100%;
 }
 

--- a/app/pages/App/styles.css
+++ b/app/pages/App/styles.css
@@ -20,10 +20,10 @@ body {
 
 /* with a default font-size of 16px allow a minimum readable font-size of 14px */
 $base-font-size: 0.875rem;
-$base-viewport-width: 58;
-$base-viewport-height: 67;
+$base-viewport-width: 50;
+$base-viewport-height: 60;
 $aspect-ratio: $base-viewport-width/$base-viewport-height;
-$growth-scaler: 0.3;
+$growth-scaler: 0.4;
 $min-growth-width: calc($base-font-size * $base-viewport-width);
 $min-growth-height: calc($base-font-size * $base-viewport-height);
 

--- a/app/pages/HomePage/index.js
+++ b/app/pages/HomePage/index.js
@@ -35,7 +35,7 @@ export class HomePage extends React.Component {
       <main className={ styles.homePage }>
         <nav className={ styles.nav } >
           <Button icon="download" outlined collapsable href="https://github.com/mxstbr/react-boilerplate/archive/master.zip">Download</Button>
-          <Button icon="book" href="https://github.com/mxstbr/react-boilerplate/tree/master/docs">Docs</Button>
+          <Button icon="book" href="https://github.com/mxstbr/react-boilerplate/tree/master/docs">Documentation</Button>
           <Button icon="github-logo" outlined collapsable href="https://github.com/mxstbr/react-boilerplate">Source</Button>
         </nav>
         <header className={ styles.header }>


### PR DESCRIPTION
There's been a few things bothering me that I have noticed when I occasionally glance at the website since release. This pull request contains a selection of miscellaneous fixes for those personal nit picks. let me know if there is anything that you would like me to split out into another pull request. Here are some of those fixes:
- `<html>` was limited to device height, preventing the blue background from stretching all the way to the bottom of the page
- Supporter image was overflowing the sides on smaller devices. The image is now a bit more responsive.
- I renamed "Docs" to "Documentation" in the navigation. I feel like this is a bit more professional and looks a bit better on larger screens.
- I loosened some of the restrictions on the growth settings for the layout, as they were barely noticeable, even are larger monitors.
